### PR TITLE
Fixed deprecated errors in PEAR packages (2)

### DIFF
--- a/core_pear/Net/IMAP.php
+++ b/core_pear/Net/IMAP.php
@@ -50,7 +50,7 @@ class Net_IMAP extends Net_IMAPProtocol
                       $enableSTARTTLS = true,
                       $encoding = 'ISO-8859-1')
     {
-        $this->Net_IMAPProtocol();
+        parent::__construct();
 
 /*
 // ERP-modification: We want to do some other stuff before we connect so disable this line in the constructor
@@ -64,7 +64,7 @@ class Net_IMAP extends Net_IMAPProtocol
                       $enableSTARTTLS = true,
                       $encoding = 'ISO-8859-1')
     {
-        $this->__construct($host, $port, $enableSTARTTLS, $encoding);
+        self::__construct($host, $port, $enableSTARTTLS, $encoding);
     }
 
 

--- a/core_pear/Net/IMAPProtocol.php
+++ b/core_pear/Net/IMAPProtocol.php
@@ -186,7 +186,7 @@ class Net_IMAPProtocol
     // BC
     function Net_IMAPProtocol()
     {
-        $this->__construct();
+        self::__construct();
     }
 
 

--- a/core_pear/Net/POP3.php
+++ b/core_pear/Net/POP3.php
@@ -177,7 +177,7 @@ class Net_POP3
     // BC
     function Net_POP3()
     {
-        $this->__construct();
+        self::__construct();
     }
 
 


### PR DESCRIPTION
Fix the fix!

The constructors were called in circular loop:
( ! ) Fatal error: Maximum function nesting level of '256' reached, aborting! in /var/www/html/git/mantis13_cpm/plugins/git/EmailReporting/core_pear/Net/IMAP.php on line 48

