### PR TITLE
Upgrade step for cleaning refences + detect and fix duplicates

### DIFF
--- a/EmailReporting.php
+++ b/EmailReporting.php
@@ -656,6 +656,14 @@ class EmailReportingPlugin extends MantisPlugin
 
 			plugin_config_set( 'config_version', 15 );
 		}
+
+		if ( $t_config_version <= 15 )
+		{
+			plugin_require_api( 'core/mail_api.php' );
+			ERP_mailbox_api::clean_references_for_deleted_issues();
+
+			plugin_config_set( 'config_version', 16 );
+		}
 	}
 
 	/*
@@ -701,8 +709,8 @@ class EmailReportingPlugin extends MantisPlugin
 	 */
 	function ERP_issue_deleted( $p_event, $p_bug_id )
 	{
-		$query = 'DELETE FROM ' . plugin_table( 'msgids' ) . ' WHERE issue_id=' . db_param();
-		db_query_bound( $query, array( (int)$p_bug_id ) );
+		plugin_require_api( 'core/mail_api.php' );
+		ERP_mailbox_api::delete_references_for_bug_id( $p_bug_id );
 	}
 
 }

--- a/core/mail_api.php
+++ b/core/mail_api.php
@@ -1425,6 +1425,25 @@ class ERP_mailbox_api
 	}
 
 	# --------------------
+	# Deletes the stored references for an issue
+	# It's static to be called from main plugin event for bug deletion
+	public static function delete_references_for_bug_id( $p_bug_id )
+	{
+		$t_query = 'DELETE FROM ' . plugin_table( 'msgids' ) . ' WHERE issue_id = ' . db_param();
+		db_query_bound( $t_query, array( (int)$p_bug_id ) );
+	}
+
+	# --------------------
+	# Deletes all references linked to non existant issues
+	# It's static to be called by upgrade as a cleanup step
+	public static function clean_references_for_deleted_issues()
+	{
+		$t_query = 'DELETE FROM ' . plugin_table( 'msgids' ) . ' WHERE NOT EXISTS'
+				. '( SELECT 1 FROM ' . db_get_table( 'bug' ) . ' B WHERE B.id = issue_id )';
+		db_query_bound( $t_query );
+	}
+
+	# --------------------
 	# Saves the complete email to file
 	# Only works in debug mode
 	private function save_message_to_file( $message_type, &$p_msg )

--- a/core/mail_api.php
+++ b/core/mail_api.php
@@ -1316,9 +1316,18 @@ class ERP_mailbox_api
 		//Get the ids from Mail References(header)
 		$t_bug_id = $this->get_bug_id_from_references( $p_references );
 
-		if ( $t_bug_id !== FALSE && bug_exists( $t_bug_id ) )
+		if ( $t_bug_id !== FALSE )
 		{
-			return( $t_bug_id );
+			if( bug_exists( $t_bug_id ) )
+			{
+				return( $t_bug_id );
+			}
+			else
+			{
+				// We found a referenced bug_id that does not exists.
+				// Do a clean up of the table to avoid inconsistencies.
+				self::clean_references_for_deleted_issues();
+			}
 		}
 
 		return( FALSE );


### PR DESCRIPTION
Adding the clean up step for config upgrade.

Also:
Regarding avoiding duplicated references, this is my approach after discussion in 
https://www.mantisbt.org/bugs/view.php?id=21850
Note that the duplicated references scenario can also happen when bugs are deleted externally, bypassing the delete event.
The approach here: first cleans up the duplicates, and then insert the correct one for the current bug.