### PR TITLE
Uses own email_regex_simple

### DIFF
--- a/core/Mail/Parser.php
+++ b/core/Mail/Parser.php
@@ -315,6 +315,7 @@ class ERP_Mail_Parser
 
 		if ( isset( $structure->parts ) )
 		{
+
 			$this->setParts( $structure->parts );
 		}
 
@@ -418,12 +419,29 @@ class ERP_Mail_Parser
 		return( TRUE );
 	}
 
-	private function setParts( &$pparts, $attachment = FALSE, $p_attached_email_subject = NULL )
+	private function setParts( $parts, $attachment = FALSE, $p_attached_email_subject = NULL )
 	{
-		// turn assoc array into an indexed array with numbers
-		$parts = array_values($pparts);
+		if (!array_key_exists(0,$parts)){
+		
+			if (array_key_exists('msg_body',$parts)){
+
+
+				$decoder = new Mail_mimeDecode( $parts[msg_body] );
+				$params['include_bodies'] = TRUE;
+				$params['decode_bodies'] = TRUE;
+		
+				$structure = $decoder->decode( $params );
+				$this->setParts($structure->parts);
+				return;
+					
+			}
+			// We can't handle this attachment
+			return;
+		}
+
 
 		$i = 0;
+
 
 		if ( $attachment === TRUE && $p_attached_email_subject === NULL && !empty( $parts[ $i ]->headers[ 'subject' ] ) )
 		{
@@ -479,8 +497,12 @@ class ERP_Mail_Parser
 			$i++;
 		}
 
+
+
+
 		for ( $i; $i < count( $parts ); $i++ )
 		{
+
 			if ( 'multipart' === strtolower( $parts[ $i ]->ctype_primary ) )
 			{
 				$this->setParts( $parts[ $i ]->parts, $attachment, $p_attached_email_subject );
@@ -494,6 +516,7 @@ class ERP_Mail_Parser
 				$this->addPart( $parts[ $i ] );
 			}
 		}
+
 	}
 
 	private function addPart( &$part, $p_alternative_name = NULL )

--- a/core/Mail/Parser.php
+++ b/core/Mail/Parser.php
@@ -418,8 +418,11 @@ class ERP_Mail_Parser
 		return( TRUE );
 	}
 
-	private function setParts( &$parts, $attachment = FALSE, $p_attached_email_subject = NULL )
+	private function setParts( &$pparts, $attachment = FALSE, $p_attached_email_subject = NULL )
 	{
+		// turn assoc array into an indexed array with numbers
+		$parts = array_values($pparts);
+
 		$i = 0;
 
 		if ( $attachment === TRUE && $p_attached_email_subject === NULL && !empty( $parts[ $i ]->headers[ 'subject' ] ) )

--- a/core/mail_api.php
+++ b/core/mail_api.php
@@ -89,6 +89,10 @@ class ERP_mailbox_api
 	private $_max_file_size;
 	private $_memory_limit;
 
+
+	private $email_regex_simple="/([a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-]+)@([a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*)/";
+
+
 	# --------------------
 	# Retrieve all necessary configuration options
 	public function __construct( $p_test_only = FALSE )
@@ -1285,7 +1289,7 @@ class ERP_mailbox_api
 				break;
 
 			case 'email_no_domain':
-				if( preg_match( email_regex_simple(), $p_user_info[ 'email' ], $t_check ) )
+				if( preg_match( $this->email_regex_simple, $p_user_info[ 'email' ], $t_check ) )
 				{
 					$t_local = $t_check[ 1 ];
 					$t_domain = $t_check[ 2 ];
@@ -1348,7 +1352,7 @@ class ERP_mailbox_api
 				break;
 
 			case 'email_no_domain':
-				if( preg_match( email_regex_simple(), $p_user_info[ 'email' ], $t_check ) )
+				if( preg_match( $this->email_regex_simple, $p_user_info[ 'email' ], $t_check ) )
 				{
 					$t_local = $t_check[ 1 ];
 					$t_domain = $t_check[ 2 ];


### PR DESCRIPTION
The mantis funtion in (core/email_api.php) doesn't extract
email name and domain.
So auto regristration of new users generates always usernames
with pattern 'xyz_emailaddress_nnnn' even if chosen another
build rule in confiuration.
This is fixed now.