### PR TITLE
Use mbstring functions instead of deprecated utf8 functions

### DIFF
--- a/core/config_api.php
+++ b/core/config_api.php
@@ -1182,7 +1182,7 @@ if ( !function_exists( 'test_database_utf8' ) )
 			$t_string = $row[ 'name' ];
 			if ( !empty( $row[ 'description' ] ) )
 			{
-				$t_string .= ' - ' . utf8_substr( $row[ 'description' ], 0, 20 );
+				$t_string .= ' - ' . mb_substr( $row[ 'description' ], 0, 20 );
 			}
 
 			echo '<option value="', $row[ 'id' ], '" title="', string_attribute( $row[ 'name' ] ), '"';

--- a/core/mail_api.php
+++ b/core/mail_api.php
@@ -1350,9 +1350,9 @@ class ERP_mailbox_api
 	{
 		$t_username = $p_username;
 
-		if ( utf8_strlen( $t_username . $p_rand ) > DB_FIELD_SIZE_USERNAME )
+		if ( mb_strlen( $t_username . $p_rand ) > DB_FIELD_SIZE_USERNAME )
 		{
-			$t_username = utf8_substr( $t_username, 0, ( DB_FIELD_SIZE_USERNAME - strlen( $p_rand ) ) );
+			$t_username = mb_substr( $t_username, 0, ( DB_FIELD_SIZE_USERNAME - strlen( $p_rand ) ) );
 		}
 
 		$t_username = $t_username . $p_rand;
@@ -1399,9 +1399,9 @@ class ERP_mailbox_api
 
 		$t_realname = string_normalize( $t_realname );
 
-		if ( utf8_strlen( $t_realname ) > DB_FIELD_SIZE_REALNAME )
+		if ( mb_strlen( $t_realname ) > DB_FIELD_SIZE_REALNAME )
 		{
-			$t_realname = utf8_substr( $t_realname, 0, DB_FIELD_SIZE_REALNAME );
+			$t_realname = mb_substr( $t_realname, 0, DB_FIELD_SIZE_REALNAME );
 		}
 
 		if ( ( !function_exists( 'user_is_realname_valid' ) || user_is_realname_valid( $t_realname ) ) && user_is_realname_unique( $p_username, $t_realname ) )


### PR DESCRIPTION
utf8 functions like utf8_strlen will be deprecated in MantisBT 2.13.0 [1]

The functions are still supported but will generate DEPRCECATED messages in PHP logs.
The functions are no longer needed as we made `mbstring` a mandatory PHP extension.

[1] https://mantisbt.org/bugs/view.php?id=23214