### PR TITLE
Accept $g_due_date_default

### DIFF
--- a/core/mail_api.php
+++ b/core/mail_api.php
@@ -989,7 +989,11 @@ class ERP_mailbox_api
 
 				$t_bug_data->steps_to_reproduce		= config_get( 'default_bug_steps_to_reproduce' );
 				$t_bug_data->additional_information	= config_get( 'default_bug_additional_info' );
-				$t_bug_data->due_date				= date_get_null();
+				
+				$t_bug_data->due_date				= date_strtotime( config_get( 'due_date_default' ) );
+				if( $t_bug_data->due_date == '' ) {
+					$t_bug_data->due_date = date_get_null();
+				}
 
 				$t_bug_data->project_id				= $t_project_id;
 

--- a/core/mail_api.php
+++ b/core/mail_api.php
@@ -990,8 +990,9 @@ class ERP_mailbox_api
 				$t_bug_data->steps_to_reproduce		= config_get( 'default_bug_steps_to_reproduce' );
 				$t_bug_data->additional_information	= config_get( 'default_bug_additional_info' );
 				
+				$t_bug_due_date_writable 			= access_has_project_level( config_get( 'due_date_update_threshold' ), helper_get_current_project(), auth_get_current_user_id() );
 				$t_bug_data->due_date				= date_strtotime( config_get( 'due_date_default' ) );
-				if( $t_bug_data->due_date == '' ) {
+				if( !$t_bug_due_date_writable || $t_bug_data->due_date == '' ) {
 					$t_bug_data->due_date = date_get_null();
 				}
 

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -1,4 +1,6 @@
 Changelog:
+May 2020 - Default Due Dates are now reflected in newly created bugs
+
 Jul 2019 - EmailReporting-0.11.0
 	- Update Markdownify github master
 	- Add EmailReplyParser library


### PR DESCRIPTION
With this change new bugs are created with the default due date set in $g_due_date_default. As the configuration var suggests to be global also the EMailReporting-Plugin should reflect that setting.

Behaviour is now copied from bug_report_page.
https://github.com/mantisbt/mantisbt/blob/f2aea91ea43834a99859655fadc2838ae0cd3144/bug_report_page.php#L182