### PR TITLE
Implemented email reporter acknownledgement

### DIFF
--- a/EmailReporting.php
+++ b/EmailReporting.php
@@ -191,6 +191,9 @@ class EmailReportingPlugin extends MantisPlugin
 			// Whether the reporter should be acknownledged for the ticket creation
 			'mail_notify_reporter'			=> OFF,
 
+			// Wether the project developers should received ack email as CC
+			'mail_notify_developers'		=> OFF,
+
 			// Wether the users specified in mail_notify_custom_emails_addresses should be notified
 			'mail_notify_custom_emails'		=> OFF,
 

--- a/EmailReporting.php
+++ b/EmailReporting.php
@@ -650,6 +650,24 @@ class EmailReportingPlugin extends MantisPlugin
 
 			plugin_config_set( 'config_version', 18 );
 		}
+
+		if ( $t_config_version <= 18 )
+		{
+			$t_mailboxes = plugin_config_get( 'mailboxes', array() );
+			$t_indexes = array(
+				'custom_emails' => 'custom_emails',
+				'custom_emails_addresses' => 'custom_emails_addresses',
+			);
+
+			foreach ( $t_mailboxes AS $t_key => $t_array )
+			{
+				$t_mailboxes[ $t_key ] = $this->ERP_update_indexes( $t_array, $t_indexes );
+			}
+
+			plugin_config_set( 'mailboxes', $t_mailboxes );
+
+			plugin_config_set( 'config_version', 19 );
+		}
 	}
 
 	/*

--- a/EmailReporting.php
+++ b/EmailReporting.php
@@ -191,9 +191,6 @@ class EmailReportingPlugin extends MantisPlugin
 			// Whether the reporter should be acknownledged for the ticket creation
 			'mail_notify_reporter'			=> OFF,
 
-			// Wether the project users should receive an email notifying the ticket was created due to email reporting
-			'mail_notify_project_users'		=> OFF,
-
 			// Wether the users specified in mail_notify_custom_emails_addresses should be notified
 			'mail_notify_custom_emails'		=> OFF,
 

--- a/EmailReporting.php
+++ b/EmailReporting.php
@@ -2,6 +2,7 @@
 
 class EmailReportingPlugin extends MantisPlugin
 {
+
 	/**
 	 *  A method that populates the plugin information and minimum requirements.
 	 */
@@ -186,6 +187,18 @@ class EmailReportingPlugin extends MantisPlugin
 
 			// Whether to identify notes using Message-ID in the mail header
 			'mail_use_message_id'			=> ON,
+
+			// Whether the reporter should be acknownledged for the ticket creation
+			'mail_notify_reporter'			=> OFF,
+
+			// Wether the project users should receive an email notifying the ticket was created due to email reporting
+			'mail_notify_project_users'		=> OFF,
+
+			// Wether the users specified in mail_notify_custom_emails_addresses should be notified
+			'mail_notify_custom_emails'		=> OFF,
+
+			// Comma separated list of email address to notify
+			'mail_notify_custom_emails_addresses' => 'example1@email.com, example2@email.com',
 		);
 	}
 

--- a/core/Mail/Parser.php
+++ b/core/Mail/Parser.php
@@ -23,6 +23,7 @@ class ERP_Mail_Parser
 	private $_file;
 	private $_content;
 
+	private $_date;
 	private $_from;
 	private $_to;
 	private $_cc;
@@ -270,6 +271,11 @@ class ERP_Mail_Parser
 		return( $this->_from );
 	}
 
+	public function date()
+	{
+		return( $this->_date );
+	}
+
 	public function to()
 	{
 		return( $this->_to );
@@ -325,6 +331,11 @@ class ERP_Mail_Parser
 		if ( isset( $structure->headers[ 'from' ] ) )
 		{
 			$this->setFrom( $structure->headers[ 'from' ] );
+		}
+
+		if ( isset( $structure->headers[ 'date' ] ) )
+		{
+			$this->setDate( $structure->headers[ 'date' ] );
 		}
 
 		if ( isset( $structure->headers[ 'subject' ] ) )
@@ -408,6 +419,11 @@ class ERP_Mail_Parser
 	private function setFrom( $from )
 	{
 		$this->_from = $this->process_header_encoding( $from );
+	}
+
+	private function setDate( $date )
+	{
+		$this->_date = $this->process_header_encoding( $date );
 	}
 
 	private function setTo( $to )

--- a/core/config_api.php
+++ b/core/config_api.php
@@ -13,6 +13,8 @@
 			'encryption'			=> 'None',
 			'ssl_cert_verify'		=> ON,
 			'auth_method'			=> 'USER',
+			'custom_emails'			=> OFF,
+			'custom_emails_addresses' => '',
 		);
 
 		return( $t_mailbox );

--- a/core/mail_api.php
+++ b/core/mail_api.php
@@ -1984,7 +1984,7 @@ class ERP_mailbox_api
 			}
 
 			$headers = [
-				'Cc' => implode(',', $ccAddr),
+				'Cc' => implode(', ', $ccAddr),
 				'Reply-To' => $this->getPluginEmailAddr(),
 			];
 

--- a/core/mail_api.php
+++ b/core/mail_api.php
@@ -1976,7 +1976,7 @@ class ERP_mailbox_api
 
 			$headers = [
 				'Cc' => implode(',', $ccAddr),
-				'From' => $this->getPluginEmailAddr(),
+				'Reply-To' => $this->getPluginEmailAddr(),
 			];
 
 			// Add mail to mantis output queue
@@ -2002,7 +2002,7 @@ class ERP_mailbox_api
 					);
 
 				$headers = [
-					'From' => $this->getPluginEmailAddr(),
+					'Reply-To' => $this->getPluginEmailAddr(),
 				];
 
 				// Add mail to mantis output queue

--- a/core/mail_api.php
+++ b/core/mail_api.php
@@ -1984,12 +1984,11 @@ class ERP_mailbox_api
 			}
 
 			$headers = [
-				'Cc' => implode(', ', $ccAddr),
 				'Reply-To' => $this->getPluginEmailAddr(),
 			];
 
 			// Add mail to mantis output queue
-			email_store($senderEmailAddr, $mailSubject, $mailBody, $headers);
+			email_store($senderEmailAddr, $mailSubject, $mailBody, $headers, true, $ccAddr);
 		}
 
 	}

--- a/core/mail_api.php
+++ b/core/mail_api.php
@@ -700,6 +700,7 @@ class ERP_mailbox_api
 		$t_mp->parse();
 
 		$t_email[ 'From_parsed' ] = $this->parse_from_field( trim( $t_mp->from() ) );
+		$t_email[ 'Date_parsed' ] = $this->parse_date_field( trim( $t_mp->date() ) );
 		$t_email[ 'Reporter_id' ] = $this->get_user( $t_email[ 'From_parsed' ] );
 
 		$t_email[ 'Subject' ] = trim( $t_mp->subject() );
@@ -1338,6 +1339,13 @@ class ERP_mailbox_api
 		}
 
 		return( $v_from_address );
+	}
+
+	# --------------------
+	# Return the date from the mail's 'Date' field
+	private function parse_date_field( $p_date )
+	{
+		return strtotime($p_date);
 	}
 
 	# --------------------
@@ -1990,6 +1998,12 @@ class ERP_mailbox_api
 	}
 
 	# --------------------
+	# Apply "mail" type quotation to a text (prepends > to any line)
+	private function quoteMailText($text) {
+		return preg_replace('/^/m', '> ', $text);
+	}
+
+	# --------------------
 	# Fills the placeholders with data from the issue
 	# Supported placeholders:
 	#   %bugid% Mantis numeric bug identifier
@@ -2004,6 +2018,9 @@ class ERP_mailbox_api
 			'%reporteremail%',
 			'%reportername%',
 			'%emailaddr%',
+			'%emailsubject%',
+			'%emailbody%',
+			'%emaildate%',
 		],
 		[
 			$bugData->id,
@@ -2011,6 +2028,9 @@ class ERP_mailbox_api
 			$email['From_parsed']['email'],
 			$email['From_parsed']['name'],
 			$this->getPluginEmailAddr(),
+			$email['Subject'],
+			$this->quoteMailText($email['X-Mantis-Body']),
+			strftime("%d/%m/%y %R", $email['Date_parsed'])
 		],
 		$template);
 	}

--- a/core/mail_api.php
+++ b/core/mail_api.php
@@ -86,6 +86,7 @@ class ERP_mailbox_api
 	private $_mail_use_message_id;
 	private $_mail_use_reporter;
 	private $_mail_notify_reporter;
+	private $_mail_notify_developers;
 	private $_mail_notify_custom_emails;
 	private $_mail_notify_custom_emails_addresses;
 
@@ -142,6 +143,7 @@ class ERP_mailbox_api
 		$this->_mail_use_message_id				= plugin_config_get( 'mail_use_message_id' );
 		$this->_mail_use_reporter				= plugin_config_get( 'mail_use_reporter' );
 		$this->_mail_notify_reporter			= plugin_config_get( 'mail_notify_reporter' );
+		$this->_mail_notify_developers			= plugin_config_get( 'mail_notify_developers' );
 		$this->_mail_notify_custom_emails		= plugin_config_get( 'mail_notify_custom_emails' );
 		$this->_mail_notify_custom_emails_addresses = plugin_config_get( 'mail_notify_custom_emails_addresses' );
 
@@ -1960,6 +1962,18 @@ class ERP_mailbox_api
 			foreach ($email['Cc'] as $cc) {
 				$ccAddr[] = $cc;
 			}
+
+			if ($this->_mail_notify_developers) {
+				// Notify project users
+				$bugUsersEmails = email_collect_recipients($bugData->id, 'new');
+				foreach ($bugUsersEmails as $bugUserId => $bugUserEmail) {
+					// Do not send to reporter
+					if ($bugUserEmail === $senderEmailAddr)
+						continue;
+					$ccAddr[] = $bugUserEmail;
+				}
+			}
+
 			$headers = [
 				'Cc' => implode(',', $ccAddr),
 				'From' => $this->getPluginEmailAddr(),

--- a/core/mail_api.php
+++ b/core/mail_api.php
@@ -2005,7 +2005,7 @@ class ERP_mailbox_api
 
 		if (in_array($value, $array))
 			return;
-		$array[] = $value;
+		$array[] = trim($value);
 	}
 
 	# --------------------

--- a/doc/CHANGELOG.txt
+++ b/doc/CHANGELOG.txt
@@ -25,6 +25,7 @@ Changelog:
 	- Handle "on behalf of" from fields properly
 	- Added condition for showing EmailReporting menu
 	- Fix reference message ID split over multiple lines (seanm)
+	- Added support for reporter acknownledge email
 
 May 2018 - EmailReporting-0.10.1
 	- Added error if, on installation, 'api/soap/mc_file_api.php' is missing

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -31,6 +31,7 @@ $s_plugin_EmailReporting_reporter_options = 'Issue reporter configuration option
 $s_plugin_EmailReporting_runtime_options = 'Runtime configuration options';
 $s_plugin_EmailReporting_security_options = 'Security configuration options';
 $s_plugin_EmailReporting_strip_signature_feature_options = 'Strip signature configuration options (Experimental)';
+$s_plugin_EmailReporting_notifications_options = 'Email notification options';
 
 $s_plugin_EmailReporting_copy_of = 'Copy of';
 $s_plugin_EmailReporting_directory_exists = 'Directory found';
@@ -77,6 +78,10 @@ $s_plugin_EmailReporting_mail_subject_id_regex = 'What kind of search should be 
 $s_plugin_EmailReporting_mail_use_bug_priority = 'Look for priority header field';
 $s_plugin_EmailReporting_mail_use_message_id = 'Use Message-ID in Mail header to identify notes';
 $s_plugin_EmailReporting_mail_use_reporter = 'Use only default reporter user for issues created by email';
+$s_plugin_EmailReporting_mail_notify_reporter = 'Send email to reporter to acknownledge bug creation';
+$s_plugin_EmailReporting_mail_notify_project_users = 'Send email to project users when a bug is created by reporter email';
+$s_plugin_EmailReporting_mail_notify_custom_emails = 'Send email to following email addresses when a bug is created by reporter email';
+$s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Comma separated static list of email addresses to be notified';
 
 $s_plugin_EmailReporting_strict = 'Strict';
 $s_plugin_EmailReporting_balanced = 'Balanced';
@@ -175,5 +180,17 @@ $s_plugin_EmailReporting_act_issue_custom_field = 'Update custom field';
 
 $s_plugin_EmailReporting_excep_issue_summary = 'Issue summary';
 $s_plugin_EmailReporting_excep_issue_description = 'Issue description';
+
+$s_plugin_EmailReporting_notify_reporter_bug_added_subject_bugcreated = 'Received bug report';
+$s_plugin_EmailReporting_notify_reporter_bug_added_body_dear = 'Dear';
+$s_plugin_EmailReporting_notify_reporter_bug_added_body_bugcreated_1 = 'we received your bug report';
+$s_plugin_EmailReporting_notify_reporter_bug_added_body_bugcreated_2 = 'and created issue';
+$s_plugin_EmailReporting_notify_dev_bug_added_subject_bugcreated = 'Received bug report';
+$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_1 = 'Issue';
+$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_2 = 'was created due to email report';
+$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_3 = 'from';
+$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_4 = 'The content of the issue is:';
+
+
 
 ?>

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -79,7 +79,6 @@ $s_plugin_EmailReporting_mail_use_bug_priority = 'Look for priority header field
 $s_plugin_EmailReporting_mail_use_message_id = 'Use Message-ID in Mail header to identify notes';
 $s_plugin_EmailReporting_mail_use_reporter = 'Use only default reporter user for issues created by email';
 $s_plugin_EmailReporting_mail_notify_reporter = 'Send email to reporter to acknowledge bug creation';
-$s_plugin_EmailReporting_mail_notify_project_users = 'Send email to project users when a bug is created by reporter email';
 $s_plugin_EmailReporting_mail_notify_custom_emails = 'Send email to following email addresses when a bug is created by reporter email';
 $s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Comma separated static list of email addresses to be notified';
 
@@ -113,6 +112,7 @@ $s_plugin_EmailReporting_update_configuration = 'Update configuration';
 $s_plugin_EmailReporting_enabled = 'Enabled';
 $s_plugin_EmailReporting_disabled = 'Disabled';
 $s_plugin_EmailReporting_description = 'Description';
+$s_plugin_EmailReporting_address = 'Email address';
 $s_plugin_EmailReporting_mailbox_type = 'Mailbox type';
 $s_plugin_EmailReporting_hostname = 'Hostname';
 $s_plugin_EmailReporting_port = 'TCP port (optional)';
@@ -185,6 +185,6 @@ $s_plugin_EmailReporting_notify_reporter_bug_added_subject = '[%bugid%] Report r
 $s_plugin_EmailReporting_notify_reporter_bug_added_body = 'The report has been received and will be processed as soon as possible. You can use the code %bugid% as a reference in the future. By answering this email and leaving %emailaddr% in the recipients and [%bugid%] as subject, you can add more informations.';
 
 $s_plugin_EmailReporting_notify_staticlist_bug_added_subject = '[%bugid%] has been created after an email report';
-$s_plugin_EmailReporting_notify_staticlist_bug_added_body = '%bugtitle% report was received by %reporteremail% and will be processed as soon as possible. You can use the code %bugid% as a reference. You can use the code %bugid% as a reference in the future. By answering this email and leaving %emailaddr% in the recipients and [%bugid%] as subject, you can add more informations.';
+$s_plugin_EmailReporting_notify_staticlist_bug_added_body = '%bugtitle% report was received by %reporteremail% and will be processed as soon as possible. You can use the code %bugid% as a reference in the future. By answering this email and leaving %emailaddr% in the recipients and [%bugid%] as subject, you can add more informations.';
 
 ?>

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -80,7 +80,7 @@ $s_plugin_EmailReporting_mail_use_message_id = 'Use Message-ID in Mail header to
 $s_plugin_EmailReporting_mail_use_reporter = 'Use only default reporter user for issues created by email';
 $s_plugin_EmailReporting_mail_notify_reporter = 'Send email to reporter to acknowledge bug creation';
 $s_plugin_EmailReporting_mail_notify_developers = 'Project developers receive the acknowledge mail as CC';
-$s_plugin_EmailReporting_mail_notify_custom_emails = 'Send email to following email addresses when a bug is created by reporter email';
+$s_plugin_EmailReporting_mail_notify_custom_emails = 'Add the following email addresses in CC when replying to reporter email';
 $s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Comma separated static list of email addresses to be notified';
 
 $s_plugin_EmailReporting_strict = 'Strict';
@@ -185,7 +185,8 @@ $s_plugin_EmailReporting_excep_issue_description = 'Issue description';
 $s_plugin_EmailReporting_notify_reporter_bug_added_subject = '[%bugid%] Report received';
 $s_plugin_EmailReporting_notify_reporter_bug_added_body = 'The report has been received and will be processed as soon as possible. You can use the code %bugid% as a reference in the future. By answering this email and leaving %emailaddr% in the recipients and [%bugid%] as subject, you can add more informations.';
 
-$s_plugin_EmailReporting_notify_staticlist_bug_added_subject = '[%bugid%] has been created after an email report';
-$s_plugin_EmailReporting_notify_staticlist_bug_added_body = '%bugtitle% report was received by %reporteremail% and will be processed as soon as possible. You can use the code %bugid% as a reference in the future. By answering this email and leaving %emailaddr% in the recipients and [%bugid%] as subject, you can add more informations.';
+$s_plugin_EmailReporting_mailbox_settings_notifications_options = '	Email notification options';
+$s_plugin_EmailReporting_custom_emails = 'Add the following email addresses in CC when replying to reporter email';
+$s_plugin_EmailReporting_custom_emails_addresses = 'Lista estática separada por comas de direcciones de correo electrónico a notificar (se agregarán a las definidas en la configuración general)';
 
 ?>

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -79,6 +79,7 @@ $s_plugin_EmailReporting_mail_use_bug_priority = 'Look for priority header field
 $s_plugin_EmailReporting_mail_use_message_id = 'Use Message-ID in Mail header to identify notes';
 $s_plugin_EmailReporting_mail_use_reporter = 'Use only default reporter user for issues created by email';
 $s_plugin_EmailReporting_mail_notify_reporter = 'Send email to reporter to acknowledge bug creation';
+$s_plugin_EmailReporting_mail_notify_developers = 'Project developers receive the acknowledge mail as CC';
 $s_plugin_EmailReporting_mail_notify_custom_emails = 'Send email to following email addresses when a bug is created by reporter email';
 $s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Comma separated static list of email addresses to be notified';
 

--- a/lang/strings_german.txt
+++ b/lang/strings_german.txt
@@ -79,7 +79,6 @@ $s_plugin_EmailReporting_mail_use_bug_priority = 'Suche nach der Priorität im H
 $s_plugin_EmailReporting_mail_use_message_id = 'Benutze die Message-ID im Header um Notizen zu identifizieren';
 $s_plugin_EmailReporting_mail_use_reporter = 'Benutze nur den Standard Reporter zur Erstellung von Tickets';
 $s_plugin_EmailReporting_mail_notify_reporter = 'Senden Sie eine E-Mail an den Reporter, um die Fehlererstellung zu bestätigen';
-$s_plugin_EmailReporting_mail_notify_project_users = 'E-Mail an Projekt Benutzer senden, wenn ein Fehler durch die E-Mail des Reporters erstellt wird';
 $s_plugin_EmailReporting_mail_notify_custom_emails = 'Senden Sie eine E-Mail an die folgenden E-Mail-Adressen, wenn ein Fehler durch eine Melder-E-Mail generiert wird';
 $s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Durch Kommas getrennte statische Liste von E-Mail-Adressen, die benachrichtigt werden sollen';
 
@@ -113,6 +112,7 @@ $s_plugin_EmailReporting_update_configuration = 'Aktualisiere die Konfiguration'
 $s_plugin_EmailReporting_enabled = 'Aktivieren';
 $s_plugin_EmailReporting_disabled = 'Deaktivieren';
 $s_plugin_EmailReporting_description = 'Beschreibung';
+$s_plugin_EmailReporting_address = 'E-Mail-Adresse';
 $s_plugin_EmailReporting_mailbox_type = 'Mailboxtyp';
 $s_plugin_EmailReporting_hostname = 'Hostname';
 $s_plugin_EmailReporting_port = 'TCP Port (optional)';

--- a/lang/strings_german.txt
+++ b/lang/strings_german.txt
@@ -181,14 +181,7 @@ $s_plugin_EmailReporting_act_issue_custom_field = 'Benutzerdefiniertes Feld aktu
 $s_plugin_EmailReporting_excep_issue_summary = 'Zusammenfassung';
 $s_plugin_EmailReporting_excep_issue_description = 'Beschreibung';
 
-$s_plugin_EmailReporting_notify_reporter_bug_added_subject_bugcreated = 'Received bug report';
-$s_plugin_EmailReporting_notify_reporter_bug_added_body_dear = 'Dear';
-$s_plugin_EmailReporting_notify_reporter_bug_added_body_bugcreated_1 = 'we received your bug report';
-$s_plugin_EmailReporting_notify_reporter_bug_added_body_bugcreated_2 = 'and created issue';
-$s_plugin_EmailReporting_notify_dev_bug_added_subject_bugcreated = 'Received bug report';
-$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_1 = 'Issue';
-$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_2 = 'was created due to email report';
-$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_3 = 'from';
-$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_4 = 'The content of the issue is:';
+$s_plugin_EmailReporting_notify_reporter_bug_added_subject = '[%bugid%] Segnalazione ricevuta';
+$s_plugin_EmailReporting_notify_reporter_bug_added_body = 'La segnalazione è stata ricevuta e sarà lavorata prima possibile. Puoi usare il codice %bugid% per farvi riferimento in futuro. Rispondendo a questa email e lasciando %emailaddr% tra i destinatari e [%buid%] nell'oggetto puoi aggiungere ulteriori informazioni.';
 
 ?>

--- a/lang/strings_german.txt
+++ b/lang/strings_german.txt
@@ -31,6 +31,7 @@ $s_plugin_EmailReporting_reporter_options = 'Konfigurationsoptionen für Ticketr
 $s_plugin_EmailReporting_runtime_options = 'Konfigurationsoptionen für Laufzeit';
 $s_plugin_EmailReporting_security_options = 'Konfigurationsoptionen für Sicherheit';
 $s_plugin_EmailReporting_strip_signature_feature_options = 'Konfigurationsoptionen zur Entfernung von Signaturen (experimentell)';
+$s_plugin_EmailReporting_notifications_options = 'Email notification options';
 
 $s_plugin_EmailReporting_copy_of = 'Kopie von';
 $s_plugin_EmailReporting_directory_exists = 'Order gefunden';
@@ -77,6 +78,10 @@ $s_plugin_EmailReporting_mail_subject_id_regex = 'Wie soll die TicketID im Betre
 $s_plugin_EmailReporting_mail_use_bug_priority = 'Suche nach der Priorität im Header';
 $s_plugin_EmailReporting_mail_use_message_id = 'Benutze die Message-ID im Header um Notizen zu identifizieren';
 $s_plugin_EmailReporting_mail_use_reporter = 'Benutze nur den Standard Reporter zur Erstellung von Tickets';
+$s_plugin_EmailReporting_mail_notify_reporter = 'Send email to reporter to acknownledge bug creation';
+$s_plugin_EmailReporting_mail_notify_project_users = 'Send email to project users when a bug is created by reporter email';
+$s_plugin_EmailReporting_mail_notify_custom_emails = 'Send email to following email addresses when a bug is created by reporter email';
+$s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Comma separated static list of email addresses to be notified';
 
 $s_plugin_EmailReporting_strict = 'Strikt';
 $s_plugin_EmailReporting_balanced = 'Ausgewogen';
@@ -175,5 +180,15 @@ $s_plugin_EmailReporting_act_issue_custom_field = 'Benutzerdefiniertes Feld aktu
 
 $s_plugin_EmailReporting_excep_issue_summary = 'Zusammenfassung';
 $s_plugin_EmailReporting_excep_issue_description = 'Beschreibung';
+
+$s_plugin_EmailReporting_notify_reporter_bug_added_subject_bugcreated = 'Received bug report';
+$s_plugin_EmailReporting_notify_reporter_bug_added_body_dear = 'Dear';
+$s_plugin_EmailReporting_notify_reporter_bug_added_body_bugcreated_1 = 'we received your bug report';
+$s_plugin_EmailReporting_notify_reporter_bug_added_body_bugcreated_2 = 'and created issue';
+$s_plugin_EmailReporting_notify_dev_bug_added_subject_bugcreated = 'Received bug report';
+$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_1 = 'Issue';
+$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_2 = 'was created due to email report';
+$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_3 = 'from';
+$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_4 = 'The content of the issue is:';
 
 ?>

--- a/lang/strings_german.txt
+++ b/lang/strings_german.txt
@@ -79,6 +79,7 @@ $s_plugin_EmailReporting_mail_use_bug_priority = 'Suche nach der Priorität im H
 $s_plugin_EmailReporting_mail_use_message_id = 'Benutze die Message-ID im Header um Notizen zu identifizieren';
 $s_plugin_EmailReporting_mail_use_reporter = 'Benutze nur den Standard Reporter zur Erstellung von Tickets';
 $s_plugin_EmailReporting_mail_notify_reporter = 'Senden Sie eine E-Mail an den Reporter, um die Fehlererstellung zu bestätigen';
+$s_plugin_EmailReporting_mail_notify_developers = 'Projektentwickler erhalten die Bestätigungsmail als CC';
 $s_plugin_EmailReporting_mail_notify_custom_emails = 'Senden Sie eine E-Mail an die folgenden E-Mail-Adressen, wenn ein Fehler durch eine Melder-E-Mail generiert wird';
 $s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Durch Kommas getrennte statische Liste von E-Mail-Adressen, die benachrichtigt werden sollen';
 

--- a/lang/strings_german.txt
+++ b/lang/strings_german.txt
@@ -80,7 +80,7 @@ $s_plugin_EmailReporting_mail_use_message_id = 'Benutze die Message-ID im Header
 $s_plugin_EmailReporting_mail_use_reporter = 'Benutze nur den Standard Reporter zur Erstellung von Tickets';
 $s_plugin_EmailReporting_mail_notify_reporter = 'Senden Sie eine E-Mail an den Reporter, um die Fehlererstellung zu bestätigen';
 $s_plugin_EmailReporting_mail_notify_developers = 'Projektentwickler erhalten die Bestätigungsmail als CC';
-$s_plugin_EmailReporting_mail_notify_custom_emails = 'Senden Sie eine E-Mail an die folgenden E-Mail-Adressen, wenn ein Fehler durch eine Melder-E-Mail generiert wird';
+$s_plugin_EmailReporting_mail_notify_custom_emails = 'Fügen Sie die folgenden E-Mail-Adressen in CC hinzu, wenn Sie auf die E-Mail eines Reporters antworten';
 $s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Durch Kommas getrennte statische Liste von E-Mail-Adressen, die benachrichtigt werden sollen';
 
 $s_plugin_EmailReporting_strict = 'Strikt';
@@ -185,7 +185,7 @@ $s_plugin_EmailReporting_excep_issue_description = 'Beschreibung';
 $s_plugin_EmailReporting_notify_reporter_bug_added_subject = '[%bugid%] Bericht erhalten';
 $s_plugin_EmailReporting_notify_reporter_bug_added_body = 'Die Bericht ist eingegangen und wird schnellstmöglich bearbeitet. Sie können in Zukunft den Code %bugid% als Referenz verwenden. Wenn Sie diese E-Mail beantworten und %emailaddr% in den Empfängern und [%bugid%] als Betreff belassen, können Sie weitere Informationen hinzufügen.';
 
-$s_plugin_EmailReporting_notify_staticlist_bug_added_subject = '[%bugid%] wurde nach einer E-Mail-Benachrichtigung erstellt';
-$s_plugin_EmailReporting_notify_staticlist_bug_added_body = 'Der Bericht %bugtitle% von %reporteremail%  ist eingegangen und wird so schnell wie möglich bearbeitet. Sie können in Zukunft den Code %bugid% als Referenz verwenden. Wenn Sie diese E-Mail beantworten und %emailaddr% in den Empfängern und [%bugid%] als Betreff belassen, können Sie weitere Informationen hinzufügen.';
-
+$s_plugin_EmailReporting_mailbox_settings_notifications_options = 'E-Mail-Benachrichtigungsoptionen';
+$s_plugin_EmailReporting_custom_emails = 'Fügen Sie die folgenden E-Mail-Adressen in CC hinzu, wenn Sie auf die E-Mail eines Reporters antworten';
+$s_plugin_EmailReporting_custom_emails_addresses = 'Durch Kommas getrennte statische Liste der zu benachrichtigenden E-Mail-Adressen (wird zu den in der allgemeinen Konfiguration definierten hinzugefügt)';
 ?>

--- a/lang/strings_italian.txt
+++ b/lang/strings_italian.txt
@@ -80,8 +80,8 @@ $s_plugin_EmailReporting_mail_use_message_id = 'Usa l\'ID messaggio nell\'header
 $s_plugin_EmailReporting_mail_use_reporter = 'Usa solo l\'utente reporter predefinito per i problemi creati tramite email';
 $s_plugin_EmailReporting_mail_notify_reporter = 'Invia un\'email al reporter per confermare la creazione del bug';
 $s_plugin_EmailReporting_mail_notify_developers = 'Metti in cc gli sviluppatori presenti nel progetto a cui viene aggiunto il bug';
-$s_plugin_EmailReporting_mail_notify_custom_emails = 'Invia e-mail ai seguenti indirizzi e-mail quando viene creato un bug dall\'e-mail del reporter';
-$s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Elenco statico di indirizzi email da notificare separati da virgole';
+$s_plugin_EmailReporting_mail_notify_custom_emails = 'Metti in cc i seguenti indirizzi e-mail quando viene creato un bug dall\'e-mail del reporter';
+$s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Elenco statico di indirizzi email da mettere in cc separati da virgole';
 
 $s_plugin_EmailReporting_strict = 'Rigoroso';
 $s_plugin_EmailReporting_balanced = 'Bilanciato';
@@ -190,7 +190,8 @@ Rispondendo a questa email e lasciando tra i destinatari %emailaddr% e [%bugid%]
 Il %emaildate%, %reportername% <%reporteremail%> ha scritto:
 %emailbody%';
 
-$s_plugin_EmailReporting_notify_staticlist_bug_added_subject = '[%bugid%] è stato creato in seguito a segnalazione via email';
-$s_plugin_EmailReporting_notify_staticlist_bug_added_body = 'È stata ricevuta la segnalazione %bugtitle% da %reporteremail% e sarà lavorata prima possibile. Puoi usare il codice %bugid% per farvi riferimento. Rispondendo a questa email e lasciando %emailaddr% tra i destinatari e [%bugid%] nell\'oggetto puoi aggiungere un commento.';
+$s_plugin_EmailReporting_mailbox_settings_notifications_options = 'Opzioni di notifica email';
+$s_plugin_EmailReporting_custom_emails = 'Aggiungi i seguenti indirizzi e-mail in cc quando si risponde all\'e-mail del reporter';
+$s_plugin_EmailReporting_custom_emails_addresses = 'Elenco statico di indirizzi email da notificare separati da virgole (vengono aggiunti a quelli definiti nella configurazione generale)';
 
 ?>

--- a/lang/strings_italian.txt
+++ b/lang/strings_italian.txt
@@ -8,7 +8,7 @@ $s_plugin_EmailReporting_manage_config = 'Gestisci le opzioni di configurazione 
 $s_plugin_EmailReporting_manage_mailbox = 'Gestisci mailbox';
 $s_plugin_EmailReporting_manage_rule = 'Gestisci regole';
 
-$s_plugin_EmailReporting_jobsetup = 'Per raccogliere le email dalle caselle di posta è necessario aggiungere un cron job programmato che esegue uno script. Puoi eseguire lo script da 2 posizioni ma solo l'opzione 1 funzionerà come cron programmato. Entrambe eseguono le stesse task. Guardare la documentazione per esempi su come programmarli.';
+$s_plugin_EmailReporting_jobsetup = 'Per raccogliere le email dalle caselle di posta è necessario aggiungere un cron job programmato che esegue uno script. Puoi eseguire lo script da 2 posizioni ma solo l\'opzione 1 funzionerà come cron programmato. Entrambe eseguono le stesse task. Guardare la documentazione per esempi su come programmarli.';
 $s_plugin_EmailReporting_job_users = '<span class="negative">Attenzione</span>: Sembra che il cron job programmato non è eseguito con lo stesso account utente del webserver / processo PHP. Questo può causare problemi con gli allegati. <br />La SAPI per il processo programmato è molto probabilmente "cli".<br />The webserver viene eseguito con il seguente user: ';
 
 $s_plugin_EmailReporting_mailbox_settings = 'Impostazioni mailbox';
@@ -41,15 +41,15 @@ $s_plugin_EmailReporting_directory_unwritable = 'Attenzione: directory non scriv
 
 $s_plugin_EmailReporting_mail_add_bug_reports = 'Aggiungi nuove issue';
 $s_plugin_EmailReporting_mail_add_bugnotes = 'Aggiungi note';
-$s_plugin_EmailReporting_mail_add_complete_email = 'Aggiungi l'email completa negli allegati';
-$s_plugin_EmailReporting_mail_add_users_from_cc_to = 'Aggiungi utenti alla lista di monitoraggio issue dai campi Destinatario e Cc nell'header della mail';
+$s_plugin_EmailReporting_mail_add_complete_email = 'Aggiungi l\'email completa negli allegati';
+$s_plugin_EmailReporting_mail_add_users_from_cc_to = 'Aggiungi utenti alla lista di monitoraggio issue dai campi Destinatario e Cc nell\'header della mail';
 $s_plugin_EmailReporting_mail_auto_signup = 'Registra automaticamente nuovi utenti (possibile rischio per la sicurezza, vedi documentazione!)';
 $s_plugin_EmailReporting_mail_block_attachments_md5 = 'Bloccare allegati che corrispondono a questi hash MD5';
 $s_plugin_EmailReporting_mail_block_attachments_logging = 'Logga allegati bloccati nella lista "File Rifiutati"';
 $s_plugin_EmailReporting_mail_bug_priority = 'Classificare priorità bug';
 $s_plugin_EmailReporting_mail_debug = 'Debug mode';
 $s_plugin_EmailReporting_mail_debug_directory = 'Salvare contenuto email in questa directory se la debug mode è attivata';
-$s_plugin_EmailReporting_mail_debug_show_memory_usage = 'Mostra l'utilizzo della memoria nelle varie fasi del processo di elaborazione email';
+$s_plugin_EmailReporting_mail_debug_show_memory_usage = 'Mostra l\'utilizzo della memoria nelle varie fasi del processo di elaborazione email';
 $s_plugin_EmailReporting_mail_delete = 'Cancella email processate dalla mailbox';
 $s_plugin_EmailReporting_mail_disposable_email_checker = 'Abilita il controllo degli indirizzi email usa e getta di MantisBT';
 $s_plugin_EmailReporting_mail_email_receive_own = 'Permettere agli utenti di ricevere email circa le proprie operazioni (N/A se email_receive_own = ON) ';
@@ -58,29 +58,28 @@ $s_plugin_EmailReporting_mail_ignore_auto_replies = 'Ignora email di risposta au
 $s_plugin_EmailReporting_mail_max_email_body = 'Dimensione massima della descrizione o della nota aggiunta alla issue';
 $s_plugin_EmailReporting_mail_max_email_body_text = 'Aggiungi questo testo se la descrizione o la nota è stata troncata';
 $s_plugin_EmailReporting_mail_max_email_body_add_attach = 'Aggiungi la descrizione completa o la nota come allegato nel caso sia stata troncata';
-$s_plugin_EmailReporting_mail_nodescription = 'Utilizzare questo testo se non viene trovata alcuna descrizione nell'e-mail';
-$s_plugin_EmailReporting_mail_nosubject = 'Usa questo testo se non viene trovato alcun oggetto nell'e-mail';
+$s_plugin_EmailReporting_mail_nodescription = 'Utilizzare questo testo se non viene trovata alcuna descrizione nell\'e-mail';
+$s_plugin_EmailReporting_mail_nosubject = 'Usa questo testo se non viene trovato alcun oggetto nell\'e-mail';
 $s_plugin_EmailReporting_mail_parse_html = 'Analizza le email HTML ';
 $s_plugin_EmailReporting_mail_preferred_username = 'Username preferito per la creazione di nuovi utenti';
 $s_plugin_EmailReporting_mail_preferred_realname = 'Nome preferito per la creazione di nuovi utenti';
 $s_plugin_EmailReporting_mail_remove_mantis_email = 'Remove MantisBT notification emails from replies';
 $s_plugin_EmailReporting_mail_remove_replies = 'Rimuovi tutte le risposte dalle note';
-$s_plugin_EmailReporting_mail_removed_reply_text = 'Usa questo testo se le risposte sono state rimosse dall'email';
-$s_plugin_EmailReporting_mail_reporter_id = 'L'utente reporter di default / fallback per issue create tramite email';
-$s_plugin_EmailReporting_mail_respect_permissions = 'Controlla i permessi dell'utente';
+$s_plugin_EmailReporting_mail_removed_reply_text = 'Usa questo testo se le risposte sono state rimosse dall\'email';
+$s_plugin_EmailReporting_mail_reporter_id = 'L\'utente reporter di default / fallback per issue create tramite email';
+$s_plugin_EmailReporting_mail_respect_permissions = 'Controlla i permessi dell\'utente';
 $s_plugin_EmailReporting_mail_rule_system = 'Regole di sistema';
-$s_plugin_EmailReporting_mail_save_from = 'Scrivi il mittente dell'e-mail nel rapporto/nota del problema';
-$s_plugin_EmailReporting_mail_save_subject_in_note = 'Scrivi l'oggetto dell'email nella nota';
-$s_plugin_EmailReporting_mail_secured_script = 'Blocca l'esecuzione di questo script attraverso un webserver (recommended = "Yes")';
-$s_plugin_EmailReporting_mail_secured_ipaddr = 'Consenti l'accesso a bug_report_mail solo da questo indirizzo IP';
-$s_plugin_EmailReporting_mail_strip_signature = 'Elimina la firma dal corpo dell'email';
-$s_plugin_EmailReporting_mail_subject_id_regex = 'Che tipo di ricerca dovrebbe essere utilizzata per trovare l'ID della issue nell'oggetto ';
+$s_plugin_EmailReporting_mail_save_from = 'Scrivi il mittente dell\'e-mail nel rapporto/nota del problema';
+$s_plugin_EmailReporting_mail_save_subject_in_note = 'Scrivi l\'oggetto dell\'email nella nota';
+$s_plugin_EmailReporting_mail_secured_script = 'Blocca l\'esecuzione di questo script attraverso un webserver (recommended = "Yes")';
+$s_plugin_EmailReporting_mail_secured_ipaddr = 'Consenti l\'accesso a bug_report_mail solo da questo indirizzo IP';
+$s_plugin_EmailReporting_mail_strip_signature = 'Elimina la firma dal corpo dell\'email';
+$s_plugin_EmailReporting_mail_subject_id_regex = 'Che tipo di ricerca dovrebbe essere utilizzata per trovare l\'ID della issue nell\'oggetto ';
 $s_plugin_EmailReporting_mail_use_bug_priority = 'Cerca nel campo header con priorità';
-$s_plugin_EmailReporting_mail_use_message_id = 'Usa l'ID messaggio nell'header della posta per identificare le note';
-$s_plugin_EmailReporting_mail_use_reporter = 'Usa solo l'utente reporter predefinito per i problemi creati tramite email';
-$s_plugin_EmailReporting_mail_notify_reporter = 'Invia un'email al reporter per confermare la creazione del bug';
-$s_plugin_EmailReporting_mail_notify_project_users = 'Invia e-mail agli utenti del progetto quando viene creato un bug dall'e-mail del reporter';
-$s_plugin_EmailReporting_mail_notify_custom_emails = 'Invia e-mail ai seguenti indirizzi e-mail quando viene creato un bug dall'e-mail del reporter';
+$s_plugin_EmailReporting_mail_use_message_id = 'Usa l\'ID messaggio nell\'header della posta per identificare le note';
+$s_plugin_EmailReporting_mail_use_reporter = 'Usa solo l\'utente reporter predefinito per i problemi creati tramite email';
+$s_plugin_EmailReporting_mail_notify_reporter = 'Invia un\'email al reporter per confermare la creazione del bug';
+$s_plugin_EmailReporting_mail_notify_custom_emails = 'Invia e-mail ai seguenti indirizzi e-mail quando viene creato un bug dall\'e-mail del reporter';
 $s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Elenco statico di indirizzi email da notificare separati da virgole';
 
 $s_plugin_EmailReporting_strict = 'Rigoroso';
@@ -113,6 +112,7 @@ $s_plugin_EmailReporting_update_configuration = 'Aggiorna configurazione';
 $s_plugin_EmailReporting_enabled = 'Abilita';
 $s_plugin_EmailReporting_disabled = 'Disabilita';
 $s_plugin_EmailReporting_description = 'Descrizione';
+$s_plugin_EmailReporting_address = 'Indirizzo email';
 $s_plugin_EmailReporting_mailbox_type = 'Tipo mailbox';
 $s_plugin_EmailReporting_hostname = 'Hostname';
 $s_plugin_EmailReporting_port = 'porta TCP (opzionale)';
@@ -131,7 +131,7 @@ $s_plugin_EmailReporting_mail_bug_priority_array_failure = 'Il formato specifica
 $s_plugin_EmailReporting_recorddisabled = '* = Disabilitato';
 $s_plugin_EmailReporting_mbstring_unavailable = '<span class="negative">Attenzione</span>: Estensione PHP mbstring non disponibile. Questo può causare problemi nel ricevere email.';
 $s_plugin_EmailReporting_db_utf8_issue = 'Si prega di correggere eventuali problemi di confronto mostrati di seguito altrimenti MantisBT potrebbe restituire errori nelle query.';
-$s_plugin_EmailReporting_missing_user = 'L'utente selezionato non è stato trovato. Selezionane uno nuovo.';
+$s_plugin_EmailReporting_missing_user = 'L\'utente selezionato non è stato trovato. Selezionane uno nuovo.';
 $s_plugin_EmailReporting_openssl_unavailable = 'Estensione PHP OpenSSL non disponibile';
 $s_plugin_EmailReporting_test_failure = 'Operazione NON riuscita';
 $s_plugin_EmailReporting_test_success = 'Operation riuscita';
@@ -142,7 +142,7 @@ $s_plugin_EmailReporting_input_name_not_allowed = 'Il nome della variabile selez
 $s_plugin_EmailReporting_pear_load_error = 'Impossibile caricare pear.php. Ciò potrebbe essere dovuto al fatto che le impostazioni di sicurezza (open_basedir) non consentono il caricamento del repository PEAR esistente';
 $s_plugin_EmailReporting_complete_test_action_note = '<span class="negative">Warning</span>: Questo testerà una singola casella di posta nel modo più completo possibile a differenza di "Test" che eseguirà solo le attività che non modificano nulla. 
 
-Ci sono ancora piccole differenze rispetto al cron job programmato (bug_report_mail.php). Ad esempio, una delle differenze potrebbe essere l'account utente che esegue il cron job.
+Ci sono ancora piccole differenze rispetto al cron job programmato (bug_report_mail.php). Ad esempio, una delle differenze potrebbe essere l\'account utente che esegue il cron job.
 
 Utilizzare con cautela';
 $s_plugin_EmailReporting_apisoap_error = 'Manca "api/soap/mc_file_api.php". EmailReporting richiede questo file per funzionare.';
@@ -156,9 +156,9 @@ $s_plugin_EmailReporting_rule_wildcards_help = '- Caratteri wildcard: * ?
 
 $s_plugin_EmailReporting_rule_conditions_help = 'NULL';
 
-$s_plugin_EmailReporting_rule_actions_help = '- "[any]" significa che l'azione in questione verrà ignorata
+$s_plugin_EmailReporting_rule_actions_help = '- "[any]" significa che l\'azione in questione verrà ignorata
 - I campi personalizzati non collegati al progetto della issue creata saranno ignorati
-- L'elenco a discesa nei custom fields dovrebbe contenere un valore vuoto se vuoi tale opzione nell'elenco a discesa. In caso contrario, verrà sempre applicato un valore quando le condizioni specificate sono soddisfatte.';
+- L\'elenco a discesa nei custom fields dovrebbe contenere un valore vuoto se vuoi tale opzione nell\'elenco a discesa. In caso contrario, verrà sempre applicato un valore quando le condizioni specificate sono soddisfatte.';
 
 $s_plugin_EmailReporting_rule_exceptions_help = 'NULL';
 
@@ -182,9 +182,9 @@ $s_plugin_EmailReporting_excep_issue_summary = 'Riepilogo issue';
 $s_plugin_EmailReporting_excep_issue_description = 'Descrizione issue';
 
 $s_plugin_EmailReporting_notify_reporter_bug_added_subject = '[%bugid%] Segnalazione ricevuta';
-$s_plugin_EmailReporting_notify_reporter_bug_added_body = 'La segnalazione è stata ricevuta e sarà lavorata prima possibile. Puoi usare il codice %bugid% per farvi riferimento in futuro. Rispondendo a questa email e lasciando %emailaddr% tra i destinatari e [%bugid%] nell'oggetto puoi aggiungere ulteriori informazioni.';
+$s_plugin_EmailReporting_notify_reporter_bug_added_body = 'La segnalazione è stata ricevuta e sarà lavorata prima possibile. Puoi usare il codice %bugid% per farvi riferimento in futuro. Rispondendo a questa email e lasciando %emailaddr% tra i destinatari e [%bugid%] nell\'oggetto puoi aggiungere ulteriori informazioni.';
 
 $s_plugin_EmailReporting_notify_staticlist_bug_added_subject = '[%bugid%] è stato creato in seguito a segnalazione via email';
-$s_plugin_EmailReporting_notify_staticlist_bug_added_body = 'È stata ricevuta la segnalazione %bugtitle% da %reporteremail% e sarà lavorata prima possibile. Puoi usare il codice %bugid% per farvi riferimento. Rispondendo a questa email e lasciando %emailaddr% tra i destinatari e [%bugid%] nell'oggetto puoi aggiungere un commento.';
+$s_plugin_EmailReporting_notify_staticlist_bug_added_body = 'È stata ricevuta la segnalazione %bugtitle% da %reporteremail% e sarà lavorata prima possibile. Puoi usare il codice %bugid% per farvi riferimento. Rispondendo a questa email e lasciando %emailaddr% tra i destinatari e [%bugid%] nell\'oggetto puoi aggiungere un commento.';
 
 ?>

--- a/lang/strings_italian.txt
+++ b/lang/strings_italian.txt
@@ -1,5 +1,5 @@
 <?php
-$s_plugin_EmailReporting_plugin_title = 'Segnalazione email';
+$s_plugin_EmailReporting_plugin_title = 'Email Reporting';
 $s_plugin_EmailReporting_plugin_description = 'Offre la funzionalità di aggiungere issues e note via email';
 $s_plugin_EmailReporting_plugin_author = 'Indy e varie persone dopo di lui.';
 
@@ -79,6 +79,7 @@ $s_plugin_EmailReporting_mail_use_bug_priority = 'Cerca nel campo header con pri
 $s_plugin_EmailReporting_mail_use_message_id = 'Usa l\'ID messaggio nell\'header della posta per identificare le note';
 $s_plugin_EmailReporting_mail_use_reporter = 'Usa solo l\'utente reporter predefinito per i problemi creati tramite email';
 $s_plugin_EmailReporting_mail_notify_reporter = 'Invia un\'email al reporter per confermare la creazione del bug';
+$s_plugin_EmailReporting_mail_notify_developers = 'Metti in cc gli sviluppatori presenti nel progetto a cui viene aggiunto il bug';
 $s_plugin_EmailReporting_mail_notify_custom_emails = 'Invia e-mail ai seguenti indirizzi e-mail quando viene creato un bug dall\'e-mail del reporter';
 $s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Elenco statico di indirizzi email da notificare separati da virgole';
 

--- a/lang/strings_italian.txt
+++ b/lang/strings_italian.txt
@@ -183,5 +183,3 @@ $s_plugin_EmailReporting_excep_issue_description = 'Issue description';
 
 $s_plugin_EmailReporting_notify_reporter_bug_added_subject = '[%bugid%] Segnalazione ricevuta';
 $s_plugin_EmailReporting_notify_reporter_bug_added_body = 'La segnalazione è stata ricevuta e sarà lavorata prima possibile. Puoi usare il codice %bugid% per farvi riferimento in futuro. Rispondendo a questa email e lasciando %emailaddr% tra i destinatari e [%buid%] nell'oggetto puoi aggiungere ulteriori informazioni.';
-
-?>

--- a/lang/strings_italian.txt
+++ b/lang/strings_italian.txt
@@ -181,8 +181,13 @@ $s_plugin_EmailReporting_act_issue_custom_field = 'Update custom field';
 $s_plugin_EmailReporting_excep_issue_summary = 'Riepilogo issue';
 $s_plugin_EmailReporting_excep_issue_description = 'Descrizione issue';
 
-$s_plugin_EmailReporting_notify_reporter_bug_added_subject = '[%bugid%] Segnalazione ricevuta';
-$s_plugin_EmailReporting_notify_reporter_bug_added_body = 'La segnalazione è stata ricevuta e sarà lavorata prima possibile. Puoi usare il codice %bugid% per farvi riferimento in futuro. Rispondendo a questa email e lasciando %emailaddr% tra i destinatari e [%bugid%] nell\'oggetto puoi aggiungere ulteriori informazioni.';
+$s_plugin_EmailReporting_notify_reporter_bug_added_subject = 'Re: [%bugid%] %emailsubject%';
+$s_plugin_EmailReporting_notify_reporter_bug_added_body = 'La segnalazione è stata ricevuta e sarà lavorata prima possibile. Puoi usare il codice %bugid% per farvi riferimento in futuro.
+
+Rispondendo a questa email e lasciando tra i destinatari %emailaddr% e [%bugid%] nell\'oggetto puoi aggiungere ulteriori informazioni.
+
+Il %emaildate%, %reportername% <%reporteremail%> ha scritto:
+%emailbody%';
 
 $s_plugin_EmailReporting_notify_staticlist_bug_added_subject = '[%bugid%] è stato creato in seguito a segnalazione via email';
 $s_plugin_EmailReporting_notify_staticlist_bug_added_body = 'È stata ricevuta la segnalazione %bugtitle% da %reporteremail% e sarà lavorata prima possibile. Puoi usare il codice %bugid% per farvi riferimento. Rispondendo a questa email e lasciando %emailaddr% tra i destinatari e [%bugid%] nell\'oggetto puoi aggiungere un commento.';

--- a/lang/strings_spanish.txt
+++ b/lang/strings_spanish.txt
@@ -31,6 +31,7 @@ $s_plugin_EmailReporting_reporter_options = 'Configuración de reporte de solici
 $s_plugin_EmailReporting_runtime_options = 'Configuración de ambiente de ejecución';
 $s_plugin_EmailReporting_security_options = 'Configuración de seguridad';
 $s_plugin_EmailReporting_strip_signature_feature_options = 'Configuración de borrado de firma (Experimental)';
+$s_plugin_EmailReporting_notifications_options = 'Email notification options';
 
 $s_plugin_EmailReporting_copy_of = 'Copiar de';
 $s_plugin_EmailReporting_directory_exists = 'Directorio encontrado';
@@ -77,6 +78,10 @@ $s_plugin_EmailReporting_mail_subject_id_regex = 'Qué tipo de búsqueda debe ut
 $s_plugin_EmailReporting_mail_use_bug_priority = 'Buscar en el campo prioridad de la cabecera del mensaje';
 $s_plugin_EmailReporting_mail_use_message_id = 'Usar Message-ID en la cabecera del email para identificar las notas';
 $s_plugin_EmailReporting_mail_use_reporter = 'Usar solo el informador por defecto para las solicitudes creadas por email';
+$s_plugin_EmailReporting_mail_notify_reporter = 'Send email to reporter to acknownledge bug creation';
+$s_plugin_EmailReporting_mail_notify_project_users = 'Send email to project users when a bug is created by reporter email';
+$s_plugin_EmailReporting_mail_notify_custom_emails = 'Send email to following email addresses when a bug is created by reporter email';
+$s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Comma separated static list of email addresses to be notified';
 
 $s_plugin_EmailReporting_strict = 'Estricta';
 $s_plugin_EmailReporting_balanced = 'Balanceada';
@@ -172,5 +177,15 @@ $s_plugin_EmailReporting_act_issue_custom_field = 'Actualizar campo personalizad
 
 $s_plugin_EmailReporting_excep_issue_summary = 'Resumen de Solicitud';
 $s_plugin_EmailReporting_excep_issue_description = 'Descripción de Solicitud';
+
+$s_plugin_EmailReporting_notify_reporter_bug_added_subject_bugcreated = 'Received bug report';
+$s_plugin_EmailReporting_notify_reporter_bug_added_body_dear = 'Dear';
+$s_plugin_EmailReporting_notify_reporter_bug_added_body_bugcreated_1 = 'we received your bug report';
+$s_plugin_EmailReporting_notify_reporter_bug_added_body_bugcreated_2 = 'and created issue';
+$s_plugin_EmailReporting_notify_dev_bug_added_subject_bugcreated = 'Received bug report';
+$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_1 = 'Issue';
+$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_2 = 'was created due to email report';
+$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_3 = 'from';
+$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_4 = 'The content of the issue is:';
 
 ?>

--- a/lang/strings_spanish.txt
+++ b/lang/strings_spanish.txt
@@ -79,6 +79,7 @@ $s_plugin_EmailReporting_mail_use_bug_priority = 'Buscar en el campo prioridad d
 $s_plugin_EmailReporting_mail_use_message_id = 'Usar Message-ID en la cabecera del email para identificar las notas';
 $s_plugin_EmailReporting_mail_use_reporter = 'Usar solo el informador por defecto para las solicitudes creadas por email';
 $s_plugin_EmailReporting_mail_notify_reporter = 'Envíe correo electrónico al reportero para reconocer la creación de errores';
+$s_plugin_EmailReporting_mail_notify_developers = 'Los desarrolladores de proyectos reciben el correo de confirmación como CC';
 $s_plugin_EmailReporting_mail_notify_custom_emails = 'Envíe un correo electrónico a las siguientes direcciones de correo electrónico cuando el correo electrónico del reportero cree un error ';
 $s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Lista estática de direcciones de correo electrónico, separados por comas, que deben ser notificados';
 

--- a/lang/strings_spanish.txt
+++ b/lang/strings_spanish.txt
@@ -178,14 +178,8 @@ $s_plugin_EmailReporting_act_issue_custom_field = 'Actualizar campo personalizad
 $s_plugin_EmailReporting_excep_issue_summary = 'Resumen de Solicitud';
 $s_plugin_EmailReporting_excep_issue_description = 'Descripción de Solicitud';
 
-$s_plugin_EmailReporting_notify_reporter_bug_added_subject_bugcreated = 'Received bug report';
-$s_plugin_EmailReporting_notify_reporter_bug_added_body_dear = 'Dear';
-$s_plugin_EmailReporting_notify_reporter_bug_added_body_bugcreated_1 = 'we received your bug report';
-$s_plugin_EmailReporting_notify_reporter_bug_added_body_bugcreated_2 = 'and created issue';
-$s_plugin_EmailReporting_notify_dev_bug_added_subject_bugcreated = 'Received bug report';
-$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_1 = 'Issue';
-$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_2 = 'was created due to email report';
-$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_3 = 'from';
-$s_plugin_EmailReporting_notify_dev_bug_added_body_bugcreated_4 = 'The content of the issue is:';
+$s_plugin_EmailReporting_notify_reporter_bug_added_subject = '[%bugid%] Segnalazione ricevuta';
+$s_plugin_EmailReporting_notify_reporter_bug_added_body = 'La segnalazione è stata ricevuta e sarà lavorata prima possibile. Puoi usare il codice %bugid% per farvi riferimento in futuro. Rispondendo a questa email e lasciando %emailaddr% tra i destinatari e [%buid%] nell'oggetto puoi aggiungere ulteriori informazioni.';
+
 
 ?>

--- a/lang/strings_spanish.txt
+++ b/lang/strings_spanish.txt
@@ -79,7 +79,6 @@ $s_plugin_EmailReporting_mail_use_bug_priority = 'Buscar en el campo prioridad d
 $s_plugin_EmailReporting_mail_use_message_id = 'Usar Message-ID en la cabecera del email para identificar las notas';
 $s_plugin_EmailReporting_mail_use_reporter = 'Usar solo el informador por defecto para las solicitudes creadas por email';
 $s_plugin_EmailReporting_mail_notify_reporter = 'Envíe correo electrónico al reportero para reconocer la creación de errores';
-$s_plugin_EmailReporting_mail_notify_project_users = 'Envíe un correo electrónico al reportero para confirmar la creación del error ';
 $s_plugin_EmailReporting_mail_notify_custom_emails = 'Envíe un correo electrónico a las siguientes direcciones de correo electrónico cuando el correo electrónico del reportero cree un error ';
 $s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Lista estática de direcciones de correo electrónico, separados por comas, que deben ser notificados';
 
@@ -113,6 +112,7 @@ $s_plugin_EmailReporting_update_configuration = 'Actualizar Configuración';
 $s_plugin_EmailReporting_enabled = 'Habilitado';
 $s_plugin_EmailReporting_disabled = 'Inhabilitado';
 $s_plugin_EmailReporting_description = 'Descripción';
+$s_plugin_EmailReporting_address = 'Dirección de correo electrónico.';
 $s_plugin_EmailReporting_mailbox_type = 'Tipo de Buzón';
 $s_plugin_EmailReporting_hostname = 'Nombre del Servidor';
 $s_plugin_EmailReporting_port = 'Puerto TCP';

--- a/lang/strings_spanish.txt
+++ b/lang/strings_spanish.txt
@@ -80,7 +80,7 @@ $s_plugin_EmailReporting_mail_use_message_id = 'Usar Message-ID en la cabecera d
 $s_plugin_EmailReporting_mail_use_reporter = 'Usar solo el informador por defecto para las solicitudes creadas por email';
 $s_plugin_EmailReporting_mail_notify_reporter = 'Envíe correo electrónico al reportero para reconocer la creación de errores';
 $s_plugin_EmailReporting_mail_notify_developers = 'Los desarrolladores de proyectos reciben el correo de confirmación como CC';
-$s_plugin_EmailReporting_mail_notify_custom_emails = 'Envíe un correo electrónico a las siguientes direcciones de correo electrónico cuando el correo electrónico del reportero cree un error ';
+$s_plugin_EmailReporting_mail_notify_custom_emails = 'Agregue las siguientes direcciones de correo electrónico en CC al responder al correo electrónico del informante';
 $s_plugin_EmailReporting_mail_notify_custom_emails_addresses = 'Lista estática de direcciones de correo electrónico, separados por comas, que deben ser notificados';
 
 $s_plugin_EmailReporting_strict = 'Estricta';
@@ -182,7 +182,8 @@ $s_plugin_EmailReporting_excep_issue_description = 'Descripción de Solicitud';
 $s_plugin_EmailReporting_notify_reporter_bug_added_subject = '[%bugid%] Informe recibido';
 $s_plugin_EmailReporting_notify_reporter_bug_added_body = 'El informe ha sido recibido y será procesado lo antes posible. Puede utilizar el código %bugid% para consultarlo en el futuro. Si responde a este correo electrónico y deja %emailaddr% en los destinatarios y [%bugid%] en el asunto, puede agregar más información.';
 
-$s_plugin_EmailReporting_notify_staticlist_bug_added_subject = '[%bugid%] fue creado siguiendo el informe de correo electrónico ';
-$s_plugin_EmailReporting_notify_staticlist_bug_added_body = 'Se ha recibido el informe %bugtitle% de %reporteremail% y será procesado lo antes posible. Puede utilizar el código %bugid% para consultarlo en el futuro. Si responde a este correo electrónico y deja %emailaddr% en los destinatarios y [%bugid%] en el asunto, puede agregar más información.';
+$s_plugin_EmailReporting_mailbox_settings_notifications_options = 'Opciones de notificación por correo electrónico';
+$s_plugin_EmailReporting_custom_emails = 'Agregue las siguientes direcciones de correo electrónico en CC al responder al correo electrónico del informante';
+$s_plugin_EmailReporting_custom_emails_addresses = 'Elenco statico di indirizzi email da notificare separati da virgole (vengono aggiunti a quelli definiti nella configurazione generale)';
 
 ?>

--- a/pages/manage_config.php
+++ b/pages/manage_config.php
@@ -173,6 +173,13 @@ ERP_output_config_option( 'mail_remove_mantis_email', 'boolean' );
 ERP_output_config_option( 'mail_removed_reply_text', 'string' );
 ERP_output_table_close();
 
+ERP_output_table_open( 'notifications_options' );
+ERP_output_config_option( 'mail_notify_reporter', 'boolean' );
+ERP_output_config_option( 'mail_notify_project_users', 'boolean' );
+ERP_output_config_option( 'mail_notify_custom_emails', 'boolean' );
+ERP_output_config_option( 'mail_notify_custom_emails_addresses', 'string_multiline' );
+ERP_output_table_close();
+
 ERP_output_table_open( 'debug_options' );
 ERP_output_config_option( 'mail_debug', 'boolean' );
 ERP_output_config_option( 'mail_debug_directory', 'directory_string' );

--- a/pages/manage_config.php
+++ b/pages/manage_config.php
@@ -175,6 +175,7 @@ ERP_output_table_close();
 
 ERP_output_table_open( 'notifications_options' );
 ERP_output_config_option( 'mail_notify_reporter', 'boolean' );
+ERP_output_config_option( 'mail_notify_developers', 'boolean' );
 ERP_output_config_option( 'mail_notify_custom_emails', 'boolean' );
 ERP_output_config_option( 'mail_notify_custom_emails_addresses', 'string_multiline' );
 ERP_output_table_close();

--- a/pages/manage_config.php
+++ b/pages/manage_config.php
@@ -175,7 +175,6 @@ ERP_output_table_close();
 
 ERP_output_table_open( 'notifications_options' );
 ERP_output_config_option( 'mail_notify_reporter', 'boolean' );
-ERP_output_config_option( 'mail_notify_project_users', 'boolean' );
 ERP_output_config_option( 'mail_notify_custom_emails', 'boolean' );
 ERP_output_config_option( 'mail_notify_custom_emails_addresses', 'string_multiline' );
 ERP_output_table_close();

--- a/pages/manage_config_edit.php
+++ b/pages/manage_config_edit.php
@@ -43,6 +43,10 @@ $f_gpc = array(
 	'mail_use_bug_priority'			=> gpc_get_int( 'mail_use_bug_priority' ),
 	'mail_use_message_id'			=> gpc_get_int( 'mail_use_message_id' ),
 	'mail_use_reporter'				=> gpc_get_int( 'mail_use_reporter' ),
+	'mail_notify_reporter'			=> gpc_get_int( 'mail_notify_reporter' ),
+	'mail_notify_project_users'		=> gpc_get_int( 'mail_notify_project_users' ),
+	'mail_notify_custom_emails'		=> gpc_get_int( 'mail_notify_custom_emails' ),
+	'mail_notify_custom_emails_addresses' => gpc_get_string( 'mail_notify_custom_emails_addresses' ),
 );
 
 $f_mail_bug_priority				= 'array (' . "\n" . gpc_get_string( 'mail_bug_priority' ) . "\n" . ')';

--- a/pages/manage_config_edit.php
+++ b/pages/manage_config_edit.php
@@ -44,7 +44,6 @@ $f_gpc = array(
 	'mail_use_message_id'			=> gpc_get_int( 'mail_use_message_id' ),
 	'mail_use_reporter'				=> gpc_get_int( 'mail_use_reporter' ),
 	'mail_notify_reporter'			=> gpc_get_int( 'mail_notify_reporter' ),
-	'mail_notify_project_users'		=> gpc_get_int( 'mail_notify_project_users' ),
 	'mail_notify_custom_emails'		=> gpc_get_int( 'mail_notify_custom_emails' ),
 	'mail_notify_custom_emails_addresses' => gpc_get_string( 'mail_notify_custom_emails_addresses' ),
 );

--- a/pages/manage_config_edit.php
+++ b/pages/manage_config_edit.php
@@ -44,6 +44,7 @@ $f_gpc = array(
 	'mail_use_message_id'			=> gpc_get_int( 'mail_use_message_id' ),
 	'mail_use_reporter'				=> gpc_get_int( 'mail_use_reporter' ),
 	'mail_notify_reporter'			=> gpc_get_int( 'mail_notify_reporter' ),
+	'mail_notify_developers'		=> gpc_get_int( 'mail_notify_developers' ),
 	'mail_notify_custom_emails'		=> gpc_get_int( 'mail_notify_custom_emails' ),
 	'mail_notify_custom_emails_addresses' => gpc_get_string( 'mail_notify_custom_emails_addresses' ),
 );

--- a/pages/manage_mailbox.php
+++ b/pages/manage_mailbox.php
@@ -95,6 +95,11 @@ ERP_output_config_option( 'global_category_id', 'dropdown', $t_mailbox, 'print_g
 //ERP_output_config_option( 'link_rules', 'dropdown_multiselect', $t_mailbox, 'print_descriptions_option_list', $t_rules ); // Should we use this here or from the rules page?
 ERP_output_table_close();
 
+ERP_output_table_open( 'mailbox_settings_notifications_options' );
+ERP_output_config_option( 'custom_emails', 'boolean', false );
+ERP_output_config_option( 'custom_emails_addresses', 'string_multiline', '' );
+ERP_output_table_close();
+
 event_signal( 'EVENT_ERP_OUTPUT_MAILBOX_FIELDS', $f_select_mailbox );
 
 ERP_output_table_open();

--- a/pages/manage_mailbox.php
+++ b/pages/manage_mailbox.php
@@ -73,6 +73,7 @@ if ( !defined( 'PEAR_OS' ) )
 ERP_output_table_open( 'mailbox_settings' );
 ERP_output_config_option( 'enabled', 'boolean', $t_mailbox );
 ERP_output_config_option( 'description', 'string', $t_mailbox );
+ERP_output_config_option( 'address', 'string', $t_mailbox );
 ERP_output_config_option( 'mailbox_type', 'dropdown', $t_mailbox, 'print_descriptions_option_list', array( 'IMAP', 'POP3' ) );
 ERP_output_config_option( 'hostname', 'string', $t_mailbox );
 ERP_output_config_option( 'port', 'string', $t_mailbox );

--- a/pages/manage_mailbox.php
+++ b/pages/manage_mailbox.php
@@ -96,8 +96,8 @@ ERP_output_config_option( 'global_category_id', 'dropdown', $t_mailbox, 'print_g
 ERP_output_table_close();
 
 ERP_output_table_open( 'mailbox_settings_notifications_options' );
-ERP_output_config_option( 'custom_emails', 'boolean', false );
-ERP_output_config_option( 'custom_emails_addresses', 'string_multiline', '' );
+ERP_output_config_option( 'custom_emails', 'boolean', $t_mailbox );
+ERP_output_config_option( 'custom_emails_addresses', 'string_multiline', $t_mailbox );
 ERP_output_table_close();
 
 event_signal( 'EVENT_ERP_OUTPUT_MAILBOX_FIELDS', $f_select_mailbox );

--- a/pages/manage_mailbox_edit.php
+++ b/pages/manage_mailbox_edit.php
@@ -14,6 +14,7 @@ if ( $f_mailbox_action === 'add' || $f_mailbox_action === 'copy' || ( ( $f_mailb
 	$t_mailbox = array(
 		'enabled'				=> gpc_get_int( 'enabled', ON ),
 		'description'			=> gpc_get_string( 'description', '' ),
+		'address'				=> gpc_get_string( 'address', '' ),
 		'mailbox_type'			=> gpc_get_string( 'mailbox_type' ),
 		'hostname'				=> gpc_get_string( 'hostname', '' ),
 		'port'					=> gpc_get_string( 'port', '' ),
@@ -79,6 +80,7 @@ elseif ( ( $f_mailbox_action === 'test' || $f_mailbox_action === 'complete_test'
 	$t_message .= plugin_lang_get( ( ( $t_is_custom_error || PEAR::isError( $t_result ) ) ? 'test_failure' : 'test_success' ) ) . '<br /><br />';
 
 	$t_message .= plugin_lang_get( 'description' ) . ': ' . $t_mailbox_api->_mailbox[ 'description' ] . '<br />';
+	$t_message .= plugin_lang_get( 'address' ) . ': ' . $t_mailbox_api->_mailbox[ 'address' ] . '<br />';
 	$t_message .= plugin_lang_get( 'mailbox_type' ) . ': ' . $t_mailbox_api->_mailbox[ 'mailbox_type' ] . '<br />';
 	$t_message .= plugin_lang_get( 'hostname' ) . ': ' . $t_mailbox_api->_mailbox[ 'hostname' ] . '<br />';
 	$t_message .= plugin_lang_get( 'port' ) . ': ' . $t_mailbox_api->_mailbox[ 'port' ] . '<br />';

--- a/pages/manage_mailbox_edit.php
+++ b/pages/manage_mailbox_edit.php
@@ -25,6 +25,8 @@ if ( $f_mailbox_action === 'add' || $f_mailbox_action === 'copy' || ( ( $f_mailb
 		'auth_method'			=> gpc_get_string( 'auth_method' ),
 		'project_id'			=> gpc_get_int( 'project_id' ),
 		'global_category_id'	=> gpc_get_int( 'global_category_id' ),
+		'custom_emails' => gpc_get_string( 'custom_emails', '' ),
+		'custom_emails_addresses' => gpc_get_string( 'custom_emails_addresses', '' ),
 //		'link_rules'			=> gpc_get_int_array( 'link_rules', array() ),
 	);
 
@@ -89,6 +91,8 @@ elseif ( ( $f_mailbox_action === 'test' || $f_mailbox_action === 'complete_test'
 	$t_message .= plugin_lang_get( 'erp_username' ) . ': ' . $t_mailbox_api->_mailbox[ 'erp_username' ] . '<br />';
 	$t_message .= plugin_lang_get( 'erp_password' ) . ': ******' . '<br />';
 	$t_message .= plugin_lang_get( 'auth_method' ) . ': ' . $t_mailbox_api->_mailbox[ 'auth_method' ] . '<br />';
+	$t_message .= plugin_lang_get( 'custom_emails' ) . ': ' . $t_mailbox_api->_mailbox[ 'custom_emails' ] . '<br />';
+	$t_message .= plugin_lang_get( 'custom_emails_addresses' ) . ': ' . $t_mailbox_api->_mailbox[ 'custom_emails_addresses' ] . '<br />';
 
 	if ( $t_mailbox_api->_mailbox[ 'mailbox_type' ] === 'IMAP' )
 	{


### PR DESCRIPTION
Feature that allow the email reporter to receive an aknownledgment about the created bug, even if the reporter doesn't have an account on Mantis.
In addition to this, it is possible to:
- allow the dev team to receive the response mail as CC
- specify a static list of emails that will receive the response mail as CC for a single mailbox
- specify a static list of emails that will receive the response mail as CC for all mailboxes