### PR TITLE
introduced option to control whether resolved tickets should be reopened when adding notes

### DIFF
--- a/EmailReporting.php
+++ b/EmailReporting.php
@@ -47,6 +47,9 @@ class EmailReportingPlugin extends MantisPlugin
 			# Is this plugin allowed to process and add notes to existing issues
 			'mail_add_bugnotes'				=> ON,
 
+			# Should this plugin reopen resolved issues when adding notes to existing issues
+			'mail_reopen_bugs'				=> ON,
+
 			# Add complete email into the attachments
 			'mail_add_complete_email'		=> OFF,
 

--- a/core/mail_api.php
+++ b/core/mail_api.php
@@ -53,6 +53,7 @@ class ERP_mailbox_api
 
 	private $_mail_add_bug_reports;
 	private $_mail_add_bugnotes;
+	private $_mail_reopen_bugs;
 	private $_mail_add_complete_email;
 	private $_mail_add_complete_email_ext;
 	private $_mail_add_users_from_cc_to;
@@ -107,6 +108,7 @@ class ERP_mailbox_api
 
 		$this->_mail_add_bug_reports			= plugin_config_get( 'mail_add_bug_reports' );
 		$this->_mail_add_bugnotes				= plugin_config_get( 'mail_add_bugnotes' );
+		$this->_mail_reopen_bugs				= plugin_config_get( 'mail_reopen_bugs' );
 		$this->_mail_add_complete_email			= plugin_config_get( 'mail_add_complete_email' );
 		$this->_mail_add_complete_email_ext		= plugin_config_get( 'mail_add_complete_email_ext' );
 		$this->_mail_add_users_from_cc_to		= plugin_config_get( 'mail_add_users_from_cc_to' );
@@ -891,7 +893,10 @@ class ERP_mailbox_api
 
 			# Check reopen permissions
 			$t_bug = bug_get( $t_bug_id, true );
-			if ( bug_is_resolved( $t_bug_id ) && ( !$this->_mail_respect_permissions || access_can_reopen_bug( $t_bug ) ) )
+
+			if ( $this->_mail_reopen_bugs
+				&& bug_is_resolved( $t_bug_id )
+				&& ( !$this->_mail_respect_permissions || access_can_reopen_bug( $t_bug ) ) )
 			{
 				if ( !is_blank( $t_description ) )
 				{

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -40,6 +40,7 @@ $s_plugin_EmailReporting_directory_unwritable = 'Warning: directory not writable
 
 $s_plugin_EmailReporting_mail_add_bug_reports = 'Add new issues';
 $s_plugin_EmailReporting_mail_add_bugnotes = 'Add notes';
+$s_plugin_EmailReporting_mail_reopen_bugs = 'Reopen closed or resolved tickets when adding notes';
 $s_plugin_EmailReporting_mail_add_complete_email = 'Add the complete email into the attachments';
 $s_plugin_EmailReporting_mail_add_complete_email_ext = 'Extension used for the complete email attachment';
 $s_plugin_EmailReporting_mail_add_users_from_cc_to = 'Add users to issue monitoring list from Cc and To fields in mail header';

--- a/lang/strings_english.txt
+++ b/lang/strings_english.txt
@@ -40,7 +40,7 @@ $s_plugin_EmailReporting_directory_unwritable = 'Warning: directory not writable
 
 $s_plugin_EmailReporting_mail_add_bug_reports = 'Add new issues';
 $s_plugin_EmailReporting_mail_add_bugnotes = 'Add notes';
-$s_plugin_EmailReporting_mail_reopen_bugs = 'Reopen closed or resolved tickets when adding notes';
+$s_plugin_EmailReporting_mail_reopen_bugs = 'Reopen resolved tickets when adding notes';
 $s_plugin_EmailReporting_mail_add_complete_email = 'Add the complete email into the attachments';
 $s_plugin_EmailReporting_mail_add_complete_email_ext = 'Extension used for the complete email attachment';
 $s_plugin_EmailReporting_mail_add_users_from_cc_to = 'Add users to issue monitoring list from Cc and To fields in mail header';

--- a/lang/strings_german.txt
+++ b/lang/strings_german.txt
@@ -40,6 +40,7 @@ $s_plugin_EmailReporting_directory_unwritable = 'Achtung: Order nicht schreibbar
 
 $s_plugin_EmailReporting_mail_add_bug_reports = 'Erstelle ein neues Ticket';
 $s_plugin_EmailReporting_mail_add_bugnotes = 'Notiz hinzufügen';
+$s_plugin_EmailReporting_mail_reopen_bugs = 'Beim Hinzufügen von Notizen geschlossene oder gelöste Tickets wieder öffnen';
 $s_plugin_EmailReporting_mail_add_complete_email = 'Komplette Email als Anhang dem Ticket hinzufügen';
 $s_plugin_EmailReporting_mail_add_complete_email_ext = 'Extension used for the complete email attachment'; //TODO Needs translation
 $s_plugin_EmailReporting_mail_add_users_from_cc_to = 'Füge Benutzer aus den To- und Cc-Feldern als Beobachter hinzu';

--- a/lang/strings_german.txt
+++ b/lang/strings_german.txt
@@ -40,7 +40,7 @@ $s_plugin_EmailReporting_directory_unwritable = 'Achtung: Order nicht schreibbar
 
 $s_plugin_EmailReporting_mail_add_bug_reports = 'Erstelle ein neues Ticket';
 $s_plugin_EmailReporting_mail_add_bugnotes = 'Notiz hinzufügen';
-$s_plugin_EmailReporting_mail_reopen_bugs = 'Beim Hinzufügen von Notizen geschlossene oder gelöste Tickets wieder öffnen';
+$s_plugin_EmailReporting_mail_reopen_bugs = 'Beim Hinzufügen von Notizen gelöste Tickets wieder öffnen';
 $s_plugin_EmailReporting_mail_add_complete_email = 'Komplette Email als Anhang dem Ticket hinzufügen';
 $s_plugin_EmailReporting_mail_add_complete_email_ext = 'Extension used for the complete email attachment'; //TODO Needs translation
 $s_plugin_EmailReporting_mail_add_users_from_cc_to = 'Füge Benutzer aus den To- und Cc-Feldern als Beobachter hinzu';

--- a/lang/strings_spanish.txt
+++ b/lang/strings_spanish.txt
@@ -40,7 +40,7 @@ $s_plugin_EmailReporting_directory_unwritable = 'Advertencia: Directorio no modi
 
 $s_plugin_EmailReporting_mail_add_bug_reports = 'Crear nuevas solicitudes';
 $s_plugin_EmailReporting_mail_add_bugnotes = 'Agregar Notas';
-$s_plugin_EmailReporting_mail_reopen_bugs = 'Reapertura de tickets cerrados o resueltos al agregar notas';
+$s_plugin_EmailReporting_mail_reopen_bugs = 'Reapertura de tickets resueltos al agregar notas';
 $s_plugin_EmailReporting_mail_add_complete_email = 'Agregar el correo como adjunto';
 $s_plugin_EmailReporting_mail_add_complete_email_ext = 'Extension used for the complete email attachment'; //TODO Needs translation
 $s_plugin_EmailReporting_mail_add_users_from_cc_to = 'Agregar usuarios asociados como Cc a la solicitud como monitores';

--- a/lang/strings_spanish.txt
+++ b/lang/strings_spanish.txt
@@ -40,6 +40,7 @@ $s_plugin_EmailReporting_directory_unwritable = 'Advertencia: Directorio no modi
 
 $s_plugin_EmailReporting_mail_add_bug_reports = 'Crear nuevas solicitudes';
 $s_plugin_EmailReporting_mail_add_bugnotes = 'Agregar Notas';
+$s_plugin_EmailReporting_mail_reopen_bugs = 'Reapertura de tickets cerrados o resueltos al agregar notas';
 $s_plugin_EmailReporting_mail_add_complete_email = 'Agregar el correo como adjunto';
 $s_plugin_EmailReporting_mail_add_complete_email_ext = 'Extension used for the complete email attachment'; //TODO Needs translation
 $s_plugin_EmailReporting_mail_add_users_from_cc_to = 'Agregar usuarios asociados como Cc a la solicitud como monitores';

--- a/pages/manage_config.php
+++ b/pages/manage_config.php
@@ -137,6 +137,7 @@ ERP_output_table_close();
 ERP_output_table_open( 'feature_options' );
 ERP_output_config_option( 'mail_add_bug_reports', 'boolean' );
 ERP_output_config_option( 'mail_add_bugnotes', 'boolean' );
+ERP_output_config_option( 'mail_reopen_bugs', 'boolean' );
 ERP_output_config_option( 'mail_rule_system', 'disabled' ); //disabled as the rule system is not ready for use
 ERP_output_config_option( 'mail_parse_html', 'boolean' );
 ERP_output_config_option( 'mail_email_receive_own', 'boolean' );

--- a/pages/manage_config_edit.php
+++ b/pages/manage_config_edit.php
@@ -7,6 +7,7 @@ plugin_require_api( 'core/config_api.php' );
 $f_gpc = array(
 	'mail_add_bug_reports'			=> gpc_get_int( 'mail_add_bug_reports' ),
 	'mail_add_bugnotes'				=> gpc_get_int( 'mail_add_bugnotes' ),
+	'mail_reopen_bugs'				=> gpc_get_int( 'mail_reopen_bugs' ),
 	'mail_add_complete_email'		=> gpc_get_int( 'mail_add_complete_email' ),
 	'mail_add_complete_email_ext'	=> gpc_get_string( 'mail_add_complete_email_ext' ),
 	'mail_add_users_from_cc_to'		=> gpc_get_int( 'mail_add_users_from_cc_to' ),


### PR DESCRIPTION
Pull request related to https://mantisbt.org/bugs/view.php?id=35093

I tested with MantisBT 2.27.0, 2.26.4, and 2.25.2. Seems my VSC messed up the original tab size, unfortunately I didn't find out how to fix this.

This solution works for me, it may be to naive with respect to your quality requirements.

If this is merged I can also edit the plugin's wiki page to document the configuration option. I hope I haven't missed out sth. important.